### PR TITLE
Change POST to GET for employee API endpoint

### DIFF
--- a/MediatR.http
+++ b/MediatR.http
@@ -5,7 +5,6 @@ GET {{MediatRPattern_HostAddress}}/api/employee
 
 ###
 
-
 POST {{MediatRPattern_HostAddress}}/api/employee
 Content-Type: application/json
 {


### PR DESCRIPTION
Change POST to GET for employee API endpoint

Modified the HTTP request method from POST to GET for the endpoint `{{MediatRPattern_HostAddress}}/api/employee`. Removed the content type and JSON payload associated with the previous POST request.